### PR TITLE
added option to pass caps in the settings variable

### DIFF
--- a/seleniumbuilder/content/html/builder/selenium2/rcPlayback.js
+++ b/seleniumbuilder/content/html/builder/selenium2/rcPlayback.js
@@ -145,7 +145,7 @@ builder.selenium2.rcPlayback.run = function(settings, postRunCallback, jobStarte
     "browserName":browserstring||"firefox",
     "version":browserversion||"",
     "platform":platform||"ANY"
-  };
+  } || settings.caps;
   
   for (var key in settings) {
     if (!{hostPort:1, browserstring:1, browserversion: 1, platform: 1}[key]) {


### PR DESCRIPTION
CrossBrowserTesting.com has extra optional selenium caps ( "screen_resolution", "record_video", "record_network"). We at least need the ability to pass the screen_resolution into the desiredCapabilities.
